### PR TITLE
Replaced dls-controls with DiamondLightSource

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -183,24 +183,24 @@ Fixed:
 
 Initial release
 
-.. _Unreleased: https://github.com/dls-controls/annotypes/compare/0-21...HEAD
-.. _0-21: https://github.com/dls-controls/annotypes/compare/0-20...0-21
-.. _0-20: https://github.com/dls-controls/annotypes/compare/0-17...0-20
-.. _0-17: https://github.com/dls-controls/annotypes/compare/0-16...0-17
-.. _0-16: https://github.com/dls-controls/annotypes/compare/0-15...0-16
-.. _0-15: https://github.com/dls-controls/annotypes/compare/0-14...0-15
-.. _0-14: https://github.com/dls-controls/annotypes/compare/0-13...0-14
-.. _0-13: https://github.com/dls-controls/annotypes/compare/0-12...0-13
-.. _0-12: https://github.com/dls-controls/annotypes/compare/0-11...0-12
-.. _0-11: https://github.com/dls-controls/annotypes/compare/0-10...0-11
-.. _0-10: https://github.com/dls-controls/annotypes/compare/0-9-1...0-10
-.. _0-9-1: https://github.com/dls-controls/annotypes/compare/0-9...0-9-1
-.. _0-9: https://github.com/dls-controls/annotypes/compare/0-8...0-9
-.. _0-8: https://github.com/dls-controls/annotypes/compare/0-7...0-8
-.. _0-7: https://github.com/dls-controls/annotypes/compare/0-6...0-7
-.. _0-6: https://github.com/dls-controls/annotypes/compare/0-5...0-6
-.. _0-5: https://github.com/dls-controls/annotypes/compare/0-4...0-5
-.. _0-4: https://github.com/dls-controls/annotypes/compare/0-3...0-4
-.. _0-3: https://github.com/dls-controls/annotypes/compare/0-2...0-3
-.. _0-2: https://github.com/dls-controls/annotypes/compare/0-1-1...0-2
-.. _0-1-1: https://github.com/dls-controls/annotypes/compare/0-1...0-1-1
+.. _Unreleased: https://github.com/DiamondLightSource/annotypes/compare/0-21...HEAD
+.. _0-21: https://github.com/DiamondLightSource/annotypes/compare/0-20...0-21
+.. _0-20: https://github.com/DiamondLightSource/annotypes/compare/0-17...0-20
+.. _0-17: https://github.com/DiamondLightSource/annotypes/compare/0-16...0-17
+.. _0-16: https://github.com/DiamondLightSource/annotypes/compare/0-15...0-16
+.. _0-15: https://github.com/DiamondLightSource/annotypes/compare/0-14...0-15
+.. _0-14: https://github.com/DiamondLightSource/annotypes/compare/0-13...0-14
+.. _0-13: https://github.com/DiamondLightSource/annotypes/compare/0-12...0-13
+.. _0-12: https://github.com/DiamondLightSource/annotypes/compare/0-11...0-12
+.. _0-11: https://github.com/DiamondLightSource/annotypes/compare/0-10...0-11
+.. _0-10: https://github.com/DiamondLightSource/annotypes/compare/0-9-1...0-10
+.. _0-9-1: https://github.com/DiamondLightSource/annotypes/compare/0-9...0-9-1
+.. _0-9: https://github.com/DiamondLightSource/annotypes/compare/0-8...0-9
+.. _0-8: https://github.com/DiamondLightSource/annotypes/compare/0-7...0-8
+.. _0-7: https://github.com/DiamondLightSource/annotypes/compare/0-6...0-7
+.. _0-6: https://github.com/DiamondLightSource/annotypes/compare/0-5...0-6
+.. _0-5: https://github.com/DiamondLightSource/annotypes/compare/0-4...0-5
+.. _0-4: https://github.com/DiamondLightSource/annotypes/compare/0-3...0-4
+.. _0-3: https://github.com/DiamondLightSource/annotypes/compare/0-2...0-3
+.. _0-2: https://github.com/DiamondLightSource/annotypes/compare/0-1-1...0-2
+.. _0-1-1: https://github.com/DiamondLightSource/annotypes/compare/0-1...0-1-1

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -8,14 +8,14 @@ involves big changes, please file a ticket before making a pull request! We
 want to make sure you don't spend your time coding something that might not fit
 the scope of the project.
 
-.. _dls_controls repository: https://github.com/dls-controls/annotypes/issues
+.. _dls_controls repository: https://github.com/DiamondLightSource/annotypes/issues
 
 Running the tests
 -----------------
 
 To get the source source code and run the unit tests, run::
 
-    $ git clone git://github.com/dls-controls/annotypes.git
+    $ git clone git://github.com/DiamondLightSource/annotypes.git
     $ cd annotypes
     $ virtualenv --no-site-packages -p /path/to/python2.7 venv
     $ . venv/bin/activate

--- a/README.rst
+++ b/README.rst
@@ -63,7 +63,7 @@ To install the latest release, type::
 
 To install the latest code directly from source, type::
 
-    pip install git+git://github.com/dls-controls/annotypes.git
+    pip install git+git://github.com/DiamondLightSource/annotypes.git
 
 
 Changelog
@@ -80,12 +80,12 @@ License
 -------
 APACHE License. (see `LICENSE`_)
 
-.. |build_status| image:: https://travis-ci.org/dls-controls/annotypes.svg?branch=master
-    :target: https://travis-ci.org/dls-controls/annotypes
+.. |build_status| image:: https://travis-ci.org/DiamondLightSource/annotypes.svg?branch=master
+    :target: https://travis-ci.org/DiamondLightSource/annotypes
     :alt: Build Status
 
-.. |coverage| image:: https://codecov.io/gh/dls-controls/annotypes/branch/master/graph/badge.svg
-    :target: https://codecov.io/gh/dls-controls/annotypes
+.. |coverage| image:: https://codecov.io/gh/DiamondLightSource/annotypes/branch/master/graph/badge.svg
+    :target: https://codecov.io/gh/DiamondLightSource/annotypes
     :alt: Test coverage
 
 .. |pypi_version| image:: https://img.shields.io/pypi/v/annotypes.svg
@@ -99,16 +99,16 @@ APACHE License. (see `LICENSE`_)
     https://www.jetbrains.com/help/pycharm/type-hinting-in-pycharm.html
 
 .. _Python 2 examples:
-    https://github.com/dls-controls/annotypes/tree/master/annotypes/py2_examples
+    https://github.com/DiamondLightSource/annotypes/tree/master/annotypes/py2_examples
 
 .. _Python 3 examples:
-    https://github.com/dls-controls/annotypes/tree/master/annotypes/py3_examples
+    https://github.com/DiamondLightSource/annotypes/tree/master/annotypes/py3_examples
 
 .. _CHANGELOG:
-    https://github.com/dls-controls/annotypes/blob/master/CHANGELOG.rst
+    https://github.com/DiamondLightSource/annotypes/blob/master/CHANGELOG.rst
 
 .. _CONTRIBUTING:
-    https://github.com/dls-controls/annotypes/blob/master/CONTRIBUTING.rst
+    https://github.com/DiamondLightSource/annotypes/blob/master/CONTRIBUTING.rst
 
 .. _LICENSE:
-    https://github.com/dls-controls/annotypes/blob/master/LICENSE
+    https://github.com/DiamondLightSource/annotypes/blob/master/LICENSE

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     version=get_version(),
     description='Annotating type hints and comments with extra metatdata',
     long_description=open("README.rst").read(),
-    url='https://github.com/dls-controls/annotypes',
+    url='https://github.com/DiamondLightSource/annotypes',
     author='Tom Cobb',
     author_email='tom.cobb@diamond.ac.uk',
     keywords='',


### PR DESCRIPTION
Repository was automatically transferred from `dls-controls/annotypes` using https://gitlab.diamond.ac.uk/github/github-scripts